### PR TITLE
QA-639: Remove yocto reference

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,3 @@ include:
       - '.gitlab-ci-check-golang-unittests.yml'
       - '.gitlab-ci-check-commits.yml'
       - '.gitlab-ci-check-license.yml'
-
-# Keep golang version aligned with latest yocto release
-image: golang:1.17-alpine3.16


### PR DESCRIPTION
This component is not build with yocto so it can use the same golang version as the templates.

The `image` key was anyway being ignored.