### PR TITLE
feat: Add `--log-level` CLI flag and restore debug messages

### DIFF
--- a/cli/setup.go
+++ b/cli/setup.go
@@ -54,6 +54,10 @@ type setupOptionsType struct {
 	demoIntervals      bool
 }
 
+type logOptionsType struct {
+	logLevel string
+}
+
 // ------------------------------ Setup constants ------------------------------
 const ( // state enum
 	stateDeviceType = iota


### PR DESCRIPTION
Previously the user had no control on what to log. This commit implements (re-implements?) the `--log-level` flag and partially restores the messages removed at 6be7792.