### PR TITLE
ci: use base-mender-go via golang-unittests-v3 template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ include:
     file:
       - '.gitlab-ci-github-status-updates.yml'
       - '.gitlab-ci-check-golang-lint.yml'
-      - '.gitlab-ci-check-golang-unittests-v2.yml'
+      - '.gitlab-ci-check-golang-unittests-v3.yml'
       - '.gitlab-ci-check-license.yml'
   - component: gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master
 

--- a/deb-requirements.txt
+++ b/deb-requirements.txt
@@ -1,1 +1,0 @@
-libglib2.0-dev


### PR DESCRIPTION
## What
Switches the unit-test include from `golang-unittests-v2` → `golang-unittests-v3` (runs on the
pre-built `base-mender-go` image) and removes `deb-requirements.txt` (`libglib2.0-dev` is now baked).

## Why
QA-1637 pilot consumer: no more `apt-get install` at unit-test time. mender-setup is the cleanest
first consumer — its only dep is baked and it inherits Go 1.26.

## Depends on (merge order)
1. mendertesting PR #491 (the v3 template) merged to master
2. mender-test-containers PR #722 — `base-mender-go` image built/published (manual job)

CI here will be red until both land; that's expected, not a defect.

## Expected result once green
The `test:unit` job log contains **no** `apt-get install` / `go install` lines.

Ticket: QA-1637