### PR TITLE
ci: run unit tests on base-mender-go-test via GO_TEST_IMAGE

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,3 +36,8 @@ include:
   - component: gitlab.com/Northern.tech/Mender/mendertesting/release-docs-changelog@master
     inputs:
       remote_changelog_file: "23.mender-setup/docs.md"
+
+# Run unit tests on the prebuilt base-mender-go-test image (QA-1637).
+test:unit:
+  variables:
+    GO_TEST_IMAGE: "registry.gitlab.com/northern.tech/mender/mender-test-containers/base-mender-go-test:master"

--- a/deb-requirements.txt
+++ b/deb-requirements.txt
@@ -1,1 +1,0 @@
-libglib2.0-dev


### PR DESCRIPTION
## What
Opts mender-setup's `test:unit` into the prebuilt `base-mender-go` image by setting the v2
template's new `GO_TEST_IMAGE` variable, and deletes `deb-requirements.txt` (`libglib2.0-dev` is
baked into the image). The include stays `golang-unittests-v2` — no new template.

## Why
QA-1637 (epic QA-1636, pipeline robustness): no `apt-get install` / `go install` at unit-test time.
This is the first consumer of the opt-in `GO_TEST_IMAGE` approach (replaces the earlier v3-template
idea).

## Depends on (merge order)
1. mendertesting PR #496 (`GO_TEST_IMAGE` support in v2) merged
2. mender-test-containers PR #725 — `base-mender-go:master` image built/published (manual job)

CI here is red until both land — expected. Once green, the `test:unit` log has no apt/go-install lines.

Ticket: QA-1637